### PR TITLE
docs: add course series project manifest

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -1,0 +1,21 @@
+# Meta-inventory interop header; contract:
+#   meta-inventory/docs/decisions/0002-project-intelligence-spec.md section D3
+spec_version: 0.1
+project:
+  id: semester-2025-fall
+  display_name: KPC/UAA Mathematics & Statistics Course Series
+  owner_entity: jjohnson-47
+role: canonical
+peers: []
+status:
+  posture: course-taught
+  local_phase: "Fall 2025 semester preparation complete; retained as the 2017-2025 course-series aggregation host"
+  as_of: "2026-07-14"
+authority:
+  status_of_record: README.md
+# Public boundary: link only public member repositories; do not surface private
+# member repository identities.
+presentation:
+  visibility: public-promoted
+  public_alias: null
+  link_policy: link-ok

--- a/project.yaml
+++ b/project.yaml
@@ -9,7 +9,8 @@ role: canonical
 peers: []
 status:
   posture: course-taught
-  local_phase: "Fall 2025 semester preparation complete; retained as the 2017-2025 course-series aggregation host"
+  operational_state: retired
+  local_phase: "Fall 2025 teaching complete; retained as a public archive and the 2017-2025 course-series aggregation host"
   as_of: "2026-07-14"
 authority:
   status_of_record: README.md


### PR DESCRIPTION
## Summary

- add the root `project.yaml` v0.1 interop manifest
- designate `semester-2025-fall` as the canonical host for the KPC/UAA 2017-2025 mathematics and statistics course series
- record the owner-approved `course-taught`, `operational_state: retired`, `public-promoted`, and `link-ok` posture
- preserve the public boundary: public member repositories may be linked; private member repository identities must not be surfaced

## Why

The portfolio inventory groups twelve repositories under `math-course-series-kpc-2017-2025` but had no associated source manifest. The owner explicitly approved this repository as the sole aggregation host and selected a retained-public-archive posture after Fall 2025 teaching concluded.

## Impact

This gives the inventory harvester one unambiguous, remote-name-aligned manifest (`project.id: semester-2025-fall`) without scattering manifests across member repositories. It records the course series as taught and publicly promotable while making clear that active delivery automation is retired.

It does not deploy course content, expose private member identities, or change any course data.

## Validation

- manifest fast check: `OK`
- host-scoped authoritative validator from a full clone: `0 ERROR, 0 WARNING, 0 INFO`
- `git diff --check`
- only `project.yaml` changes

## Owner-approved check waiver

The owner approved merge under a documented waiver on 2026-07-14. The red Pages, lint, unit, integration, and duplicate Test Suite checks are inherited repository baseline failures and are unrelated to this manifest-only diff.

Retirement of the Pages PR gate, scheduled maintenance, orphaned dashboard deployment API, and historical orchestration-state tests will be handled in a separate change.
